### PR TITLE
Prevent auto hide on close btn visible

### DIFF
--- a/jquery.notifyBar.js
+++ b/jquery.notifyBar.js
@@ -40,8 +40,11 @@ jQuery.notifyBar = function(settings) {
     //Set up own class
     notifyBarNS.cls = settings.cls || "";
     
-    //close button
-    notifyBarNS.close = settings.close || false;
+	//close button if injected as true the delay is not needed until the hideDelayedOnCloseBtnVisible is set to true
+	notifyBarNS.close = settings.close || false;
+
+	//hide the bar even if close btn option is set to true 
+	notifyBarNS.hideDelayedOnCloseBtnVisible = settings.hideDelayedOnCloseBtnVisible || false;
     
     if( notifyBarNS.jqObject) {
       bar = notifyBarNS.jqObject;
@@ -99,11 +102,14 @@ jQuery.notifyBar = function(settings) {
     $(this).slideUp(asTime);
   })
      
-  // If taken from DOM dot not remove just hide
-  if( bar.attr("id") == "__notifyBar") {
-    setTimeout("jQuery('#" + id + "').stop().slideUp(" + asTime +", function() {jQuery('#" + id + "').remove()});", notifyBarNS.delay + asTime);
-  } else {
-    setTimeout("jQuery('#" + id + "').stop().slideUp(" + asTime +", function() {jQuery('#" + id + "')});", notifyBarNS.delay + asTime);
-  }
-
+  // check if we have to autoHide depending on close btn visbil and hideDelayedOnCloseBtnVisible
+  if (!notifyBarNS.close || (notifyBarNS.close && notifyBarNS.hideDelayedOnCloseBtnVisible)) {
+	   // If taken from DOM dot not remove just hide
+	  if( bar.attr("id") == "__notifyBar") {
+		setTimeout("jQuery('#" + id + "').stop().slideUp(" + asTime +", function() {jQuery('#" + id + "').remove()});", notifyBarNS.delay + asTime);
+	  } else {
+		setTimeout("jQuery('#" + id + "').stop().slideUp(" + asTime +", function() {jQuery('#" + id + "')});", notifyBarNS.delay + asTime);
+	  }
+	}	
+	  
 })(jQuery) };

--- a/jquery.notifyBar.js
+++ b/jquery.notifyBar.js
@@ -43,8 +43,8 @@ jQuery.notifyBar = function(settings) {
 	//close button if injected as true the delay is not needed until the hideDelayedOnCloseBtnVisible is set to true
 	notifyBarNS.close = settings.close || false;
 
-	//hide the bar even if close btn option is set to true 
-	notifyBarNS.hideDelayedOnCloseBtnVisible = settings.hideDelayedOnCloseBtnVisible || false;
+    //hide the bar even if close btn option is set to true 
+    notifyBarNS.respectHideDelay = settings.respectHideDelay == undefined ? true : settings.respectHideDelay;
     
     if( notifyBarNS.jqObject) {
       bar = notifyBarNS.jqObject;
@@ -102,8 +102,8 @@ jQuery.notifyBar = function(settings) {
     $(this).slideUp(asTime);
   })
      
-  // check if we have to autoHide depending on close btn visbil and hideDelayedOnCloseBtnVisible
-  if (!notifyBarNS.close || (notifyBarNS.close && notifyBarNS.hideDelayedOnCloseBtnVisible)) {
+    // If taken from DOM dot not remove just hide
+    if (!notifyBarNS.close || (notifyBarNS.close && notifyBarNS.respectHideDelay)) {
 	   // If taken from DOM dot not remove just hide
 	  if( bar.attr("id") == "__notifyBar") {
 		setTimeout("jQuery('#" + id + "').stop().slideUp(" + asTime +", function() {jQuery('#" + id + "').remove()});", notifyBarNS.delay + asTime);


### PR DESCRIPTION
my fork  adds the possibility to prevent the auto hide on close button visible by giving the option respectHideDelay.

If set to true the notify bar will stay open and ignore the timer which removes the bar.

If the parameter (respectHideDelay) is not given as option the bars will be removed as normal after the time of the option delay.