### PR TITLE
Add package.json, convert to UMD module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+npm-error.log

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2009-2017 Dknight
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -133,27 +133,3 @@ jQuery(function () {
 </table>
 
 Please visit [the project page](http://www.whoop.ee/posts/2013-04-05-the-resurrection-of-jquery-notify-bar/ "the project page") for feedback and other details.
-
-##  MIT License
-
-The MIT License (MIT)
-
-Copyright (c) 2009-2014 Dknight
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.

--- a/jquery.notifyBar.js
+++ b/jquery.notifyBar.js
@@ -1,4 +1,4 @@
-/*
+/**
 * Notify Bar - jQuery plugin
 *
 * Copyright (c) 2009-2016 Dmitri Smirnov
@@ -8,9 +8,37 @@
 *
 * Project home:
 * http://www.whoop.ee/posts/2013/04/05/the-resurrection-of-jquery-notify-bar.html
+*
+* Uses CommonJS, AMD or browser globals to create a jQuery plugin.
+* Ref: https://github.com/umdjs/umd/blob/master/templates/jqueryPlugin.js
 */
-(function ($) {
-
+(function (factory) {
+    if (typeof define === 'function' && define.amd) {
+        // AMD. Register as an anonymous module.
+        define(['jquery'], factory);
+    } else if (typeof module === 'object' && module.exports) {
+        // Node/CommonJS
+        module.exports = function( root, jQuery ) {
+            if ( jQuery === undefined ) {
+                // require('jQuery') returns a factory that requires window to
+                // build a jQuery instance, we normalize how we use modules
+                // that require this pattern but the window provided is a noop
+                // if it's defined (how jquery works)
+                if ( typeof window !== 'undefined' ) {
+                    jQuery = require('jquery');
+                }
+                else {
+                    jQuery = require('jquery')(root);
+                }
+            }
+            factory(jQuery);
+            return jQuery;
+        };
+    } else {
+        // Browser globals
+        factory(jQuery);
+    }
+}(function ($) {
     'use strict';
 
     $.notifyBar = function (options) {
@@ -154,4 +182,4 @@
 
         return $bar;
     };
-})(jQuery);
+}));

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,12 @@
+{
+  "name": "jqnotifybar",
+  "version": "1.5.5",
+  "lockfileVersion": 1,
+  "dependencies": {
+    "jquery": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.2.1.tgz",
+      "integrity": "sha1-XE2d5lKvbNCncBVKYxu6ErAVx4c="
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "jqnotifybar",
+  "version": "1.5.5",
+  "homepage": "http://www.whoop.ee/posts/2013/04/05/the-resurrection-of-jquery-notify-bar.html",
+  "authors": [
+    "dknight <smirnov.dmitri@gmail.com>"
+  ],
+  "description": "Small widget, which notifies user about event from top or bottom of the page.",
+  "main": "jquery.notifyBar.js",
+  "moduleType": [
+    "es5"
+  ],
+  "keywords": [
+    "ui",
+    "notity",
+    "bar",
+    "jquery"
+  ],
+  "license": "MIT",
+  "repository": "https://github.com/dknight/jQuery-Notify-bar.git",
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "bower_components",
+    "test",
+    "tests"
+  ],
+  "dependencies": {
+    "jquery": ">=1.7.1"
+  }
+}


### PR DESCRIPTION
This pull request is mainly to add npm support by basically copying the existing `bower.json` file to `package.json`. I also converted it to a module so that it can be used in AMD and CommonJS environments as well the already supported `jQuery` browser global variable.

Quick list of changes:
- Add `package.json` (module name is `jqnotifybar` which is not yet taken on NPM)
- Add UMD header in order to support AMD and CommonJS modules
- Add `.gitignore` to ignore `node_modules` and `npm-error.log`
- Move license info from embedded inside `README.md` into `LICENSE.md` file